### PR TITLE
[GCC] link error: multiple definitions

### DIFF
--- a/include/boost/expected/expected.hpp
+++ b/include/boost/expected/expected.hpp
@@ -91,11 +91,11 @@ exception_ptr make_error(Error e, exception_ptr)
 {
   return copy_exception(e);
 }
-void rethrow(exception_ptr e)
+inline void rethrow(exception_ptr e)
 {
   return rethrow_exception(e);
 }
-exception_ptr make_error_from_current_exception(exception_ptr)
+inline exception_ptr make_error_from_current_exception(exception_ptr)
 {
   return current_exception();
 }
@@ -109,11 +109,11 @@ exception_ptr make_error(Error e, exception_ptr)
 {
   return make_exception_ptr(e);
 }
-void rethrow(exception_ptr e)
+inline void rethrow(exception_ptr e)
 {
   return rethrow_exception(e);
 }
-exception_ptr make_error_from_current_exception(exception_ptr)
+inline exception_ptr make_error_from_current_exception(exception_ptr)
 {
   return current_exception();
 }


### PR DESCRIPTION
Fix for the following link errors in GCC:

expected/include/boost/expected/expected.hpp:95: error: multiple definition of `boost::rethrow(boost::exception_ptr)'
expected/include/boost/expected/expected.hpp:99: error: multiple definition of`boost::make_error_from_current_exception(boost::exception_ptr)'
expected/include/boost/expected/expected.hpp:113: error: multiple definition of `std::rethrow(std::__exception_ptr::exception_ptr)'
expected/include/boost/expected/expected.hpp:117: error: multiple definition of`std::make_error_from_current_exception(std::__exception_ptr::exception_ptr)'
